### PR TITLE
Updating Habitat URL and typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run --rm --it --volume "${PWD}/docs/:/srv/jekyll" -p 4000:4000 jekyll/jek
 The extension is written in TypeScript which is transpiled to JavaScript using a build process written, again, in TypeScript. If you wish to look at how things work and create the package on a local machine then use the following command:
 
 ```bash
-npn run build:tasks
+npm run build:tasks
 ```
 
 This will execute all of the processes that are required and create two packages in the `build` directory.

--- a/tasks/common/TaskConfiguration.ts
+++ b/tasks/common/TaskConfiguration.ts
@@ -77,7 +77,7 @@ export class TaskParameters {
                 // Set the location for habitat on a Windows machine
                 this.paths["habitat"] = path.join("C:", "ProgramData", "habitat", "hab.exe");
 
-                this.scriptUrl = "https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows";
+                this.scriptUrl = "https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-windows.zip"
 
                 this.paths["download_path"] = path.join(process.env["TEMP"], "habitat.zip");
 
@@ -97,7 +97,7 @@ export class TaskParameters {
                 this.paths["habitat"] = "/tmp/hab";
 
                 // set the default download url for habitat
-                this.scriptUrl = "https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux";
+                this.scriptUrl = "https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-linux.tar.gz";
 
                 // determine the download path
                 this.paths["download_path"] = "/tmp/hab.tar.gz";


### PR DESCRIPTION
Hello all,

This PR updates the URL for downloading Habitat to the latest URL at `packages.chef.io`. This is required to get the newest version downloads 1.5.29. 

There was also a small typo in the README.md. I changed the `npn` to `npm` for local builds. 

Please let me know if anything is missing or if there are any suggestions/questions. Thank you!