### PR TITLE
Updated version of commander as this was preventing build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typescript": "^2.9.2",
     "@types/npm": "^2.0.30",
     "uuidv5": "^1.0.0",
-    "commander": "^2.19.0"
+    "commander": "^4.1"
   },
   "dependencies": {
     "azure-pipelines-task-lib": "^2.8.0"


### PR DESCRIPTION
Build was using an out of date version of commander which prevented the extension from building.

(There was no version 3.x of commander)

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>